### PR TITLE
Removing Eval call and removing database user and pass from ToString() method

### DIFF
--- a/src/Hangfire.Mongo/MongoUtils/MongoExtensions.cs
+++ b/src/Hangfire.Mongo/MongoUtils/MongoExtensions.cs
@@ -9,10 +9,10 @@ namespace Hangfire.Mongo.MongoUtils
 	{
 		public static DateTime GetServerTimeUtc(this MongoDatabase database)
 		{
-			return database.Eval(new EvalArgs
-			{
-				Code = new BsonJavaScript("new Date()")
-			}).ToUniversalTime();
+			return database.RunCommand("serverStatus")
+				.Response
+				.AsBsonDocument["localTime"]
+				.ToUniversalTime();
 		}
 
 		public static DateTime GetServerTimeUtc(this HangfireDbContext dbContext)

--- a/tests/Hangfire.Mongo.Tests/MongoStorageFacts.cs
+++ b/tests/Hangfire.Mongo.Tests/MongoStorageFacts.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Hangfire.Mongo.Tests.Utils;
 using Hangfire.Server;
 using Hangfire.Storage;
@@ -61,6 +62,15 @@ namespace Hangfire.Mongo.Tests
 
 			Type[] componentTypes = components.Select(x => x.GetType()).ToArray();
 			Assert.Contains(typeof(ExpirationManager), componentTypes);
+		}
+
+		[Fact]
+		public void ToString_ReturnsStorageDetails()
+		{
+			MongoStorage storage = CreateStorage();
+
+			var storageDetails = storage.ToString();
+			Assert.True(Regex.IsMatch(storageDetails, @"Port: \d+"));
 		}
 
 		private static MongoStorage CreateStorage()


### PR DESCRIPTION
- Replacing Eval call which was deprecated in MongoDb 3.0
- Changing MongoStorage.ToString() method to not return the database username and password for display in the Hangfire Dashboard.